### PR TITLE
Fix: correcting url links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Entregamos **controle**, **organização** e **melhor relacionamento com o clien
 
 Nossa missão é melhorar a prestação de serviços no Brasil. 
 
-Te convido a conhecer um pouco mais da Field e da nossa **cultura** pelo nosso instagram: [@FieldControlApp](https://www.instagram.com/fieldcontrolapp/)
+Te convido a conhecer um pouco mais da Field e da nossa **cultura** pelo nosso instagram: [@FieldControl](https://www.instagram.com/fieldcontrol/)
 
 <p>
   <img src="assets/fielders.png" width="855"/>
@@ -27,7 +27,7 @@ Condições
 ----------
 - Período: Integral
 - Onde: Qualquer lugar :)
-- Benefícios: Alimentação, Plano de saúde, Seguro de vida, [Pluralsight](https://www.pluralsight.com/), [Alura](https://www.alura.com.br/), [Amazon Books](https://www.amazon.com/amazon-books/) <3
+- Benefícios: Alimentação, Plano de saúde, Seguro de vida, [Pluralsight](https://www.pluralsight.com/), [Alura](https://www.alura.com.br/), [Amazon Books](https://www.amazon.com/books-used-books-textbooks/b?ie=UTF8&node=283155) <3
 
 :house_with_garden: Você pode ler sobre nossa cidade no [G1](http://g1.globo.com/sao-paulo/sao-jose-do-rio-preto-aracatuba/especial-publicitario/prefeitura-de-rio-preto/rio-preto-noticias/noticia/2015/12/rio-preto-e-melhor-cidade-do-estado-e-segunda-do-pais-para-se-viver.html), [Infomoney](http://www.infomoney.com.br/minhas-financas/consumo/noticia/6391352/melhores-cidades-brasil-para-viver-veja-ranking) ou aqui na [Exame](https://exame.abril.com.br/brasil/o-ranking-do-servico-publico-nas-100-maiores-cidades-do-brasil/).
 


### PR DESCRIPTION
As URL dos links para o instagram da Field Control e o Amazon Books estavam incorretos e caindo em uma pagina "não encontrada"

[![Image from Gyazo](https://i.gyazo.com/07315fc7130d9576eb6fd07c1773a1a8.png)](https://gyazo.com/07315fc7130d9576eb6fd07c1773a1a8)
[![Image from Gyazo](https://i.gyazo.com/1fa9cc705b39887452a21e4a13decca6.png)](https://gyazo.com/1fa9cc705b39887452a21e4a13decca6)